### PR TITLE
Lowercase Jinja2 dependency name

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,6 +6,9 @@ source:
   git_url: https://github.com/conda-forge/conda-smithy.git
   git_tag: fa524b8a53ace66e8e2a6d59ef472cb46aaecdbc
 
+build:
+  number: 1
+
 requirements:
   build:
     - python
@@ -15,6 +18,6 @@ requirements:
     - setuptools
     - conda
     - conda-build
-    - Jinja2
+    - jinja2
     - requests
 


### PR DESCRIPTION
This allows it to match the standard jinja2 conda package.