### PR TITLE
Restrict acceptable `conda-build` versions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5ca1d91c980bb7cd64270655761e3336883b65ff2f4fc79968b6fa2da838b981
 
 build:
-    number: 0
+    number: 1
     script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - setuptools
     - conda-build-all
     - conda
-    - conda-build
+    - conda-build >=1.21.12
     - jinja2
     - requests
     - pycrypto


### PR DESCRIPTION
Restrict the `conda-build` version based on a [similar update]( https://github.com/conda-forge/conda-smithy/blob/v1.1.2/conda_smithy.recipe/meta.yaml#L23 ) in the recipe from the source repo.