### PR TITLE
Release 1.6.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: The tool for managing conda-forge feedstocks
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/conda-smithy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/conda-smithy-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/conda-smithy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/conda-smithy-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-smithy-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/conda-smithy-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-smithy/badges/version.svg)](https://anaconda.org/conda-forge/conda-smithy)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-smithy/badges/downloads.svg)](https://anaconda.org/conda-forge/conda-smithy)
+
 Installing conda-smithy
 =======================
 
@@ -66,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/conda-smithy-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/conda-smithy-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/conda-smithy-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/conda-smithy-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/conda-smithy-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/conda-smithy-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-smithy/badges/version.svg)](https://anaconda.org/conda-forge/conda-smithy)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/conda-smithy/badges/downloads.svg)](https://anaconda.org/conda-forge/conda-smithy)
 
 
 Updating conda-smithy-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ environment:
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
-  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: KDvUkPrcdKmV2MxakkyQlrLA0rE/6WSuXxD42UezzZjCB0TRqnnOeebSW03/SnFP

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.5.3" %}
+{% set version = "1.6.0" %}
 
 package:
   name: conda-smithy
@@ -7,7 +7,7 @@ package:
 source:
   fn: conda-smithy-v{{ version }}.tar.gz
   url: https://github.com/conda-forge/conda-smithy/archive/v{{ version }}.tar.gz
-  sha256: 73853671455042ce3b07d4ea5b7d45f49e731e280171d7bd6dbc4784465db663
+  sha256: 6550884bd9b4d6964cf95ff9ec80d77e3bd6ffb6e80d03c24994d9af50f04c0b
 
 build:
   number: 0


### PR DESCRIPTION
```markdown
v1.6.0

* Add `.gitattributes` to format recipe line endings. #380
* Cleanup overridden environment variables from `appveyor.yml`. #384
* Put `conda-smithy` version in initial commit of feedstock. #388
* Move feedstock badges to the top of the README. #390
```

Also re-rendered with `conda-smithy` version `1.6.0`.