### PR TITLE
Release 1.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.6.0" %}
+{% set version = "1.6.1" %}
 
 package:
   name: conda-smithy
@@ -7,7 +7,7 @@ package:
 source:
   fn: conda-smithy-v{{ version }}.tar.gz
   url: https://github.com/conda-forge/conda-smithy/archive/v{{ version }}.tar.gz
-  sha256: 6550884bd9b4d6964cf95ff9ec80d77e3bd6ffb6e80d03c24994d9af50f04c0b
+  sha256: 7fdc7dc3d4a1d93931193d586d1be26040b6b0790822a4f987eecf4c41bd78bd
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - conda-build-all
-    - conda
+    - conda 4.1.*
     - conda-build >=1.21.12,!=2.0.9
     - jinja2
     - requests


### PR DESCRIPTION
```markdown
v1.6.1

* Pin `conda` to 4.1.x in CIs as a workaround. #395
* Set `CONDA_PY` on AppVeyor (if undefined). #393
```