### PR TITLE
Adjust `py` selector for `skip`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py36]
+  skip: true  # [py==36]
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - feedstocks = conda_smithy.feedstocks:main


### PR DESCRIPTION
Should be more friendly with older `conda-build`s that do not have `py36` per se.