### PR TITLE
Remove conda symlinks

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,10 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script:
+    - python setup.py install --single-version-externally-managed --record=record.txt
+    - rm -r "${PREFIX}/bin/conda"           # [unix]
+    - del /f /q "%PREFIX%\\Scripts\\conda"  # [win]
   entry_points:
     - feedstocks = conda_smithy.feedstocks:main
     - conda-smithy = conda_smithy.cli:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: aae0a55de7466702f84c2cd4128768c64d62bc135c14003f8ab6f1dfe5e33243
 
 build:
-  number: 0
+  number: 1
   script:
     - python setup.py install --single-version-externally-managed --record=record.txt
     - rm -r "${PREFIX}/bin/conda"           # [unix]


### PR DESCRIPTION
Appears we are getting `conda` links leftovers packaged with `conda-smithy` due to a bug in `conda-build` 2.1.9. Please see issue ( https://github.com/conda/conda-build/issues/1916 ) for more details. As a workaround, manually remove these links and rebuild the package.