### PR TITLE
Release 3.1.2

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -1,6 +1,6 @@
 pin_run_as_build:
   python:
-    min_pin: x.x
     max_pin: x.x
+    min_pin: x.x
 python:
 - '2.7'

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -55,7 +55,8 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
-conda install --yes --quiet conda-forge-ci-setup=1
+# Make sure we pull in the latest conda-build version too
+conda install --yes --quiet conda-forge-ci-setup=1 conda-build
 source run_conda_forge_build_setup
 
 conda build /home/conda/recipe_root -m /home/conda/feedstock_root/.ci_support/${CONFIG}.yaml --quiet || exit 1

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ All platforms:
 Current release info
 ====================
 
-[![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/conda-smithy.svg)](https://anaconda.org/conda-forge/conda-smithy)
-[![Conda Version](https://img.shields.io/conda/vn/conda-forge/conda-smithy.svg)](https://anaconda.org/conda-forge/conda-smithy)
-[![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/conda-smithy.svg)](https://anaconda.org/conda-forge/conda-smithy)
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-conda--smithy-green.svg)](https://anaconda.org/conda-forge/conda-smithy) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/conda-smithy.svg)](https://anaconda.org/conda-forge/conda-smithy) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/conda-smithy.svg)](https://anaconda.org/conda-forge/conda-smithy) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/conda-smithy.svg)](https://anaconda.org/conda-forge/conda-smithy) |
 
 Installing conda-smithy
 =======================

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.1.1" %}
+{% set version = "3.1.2" %}
 
 package:
   name: conda-smithy
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/conda-forge/conda-smithy/releases/download/v{{ version }}/conda-smithy-{{ version }}.tar.gz
-  sha256: 95d6628ead81e6ae3f20c074aed21e758557c018217f5ab95841fc71262d71f7
+  sha256: 30d3b6ec1050831b7fb0701109aae03264f24a0b6891d1377726f815580dac0e
 
 build:
   number: 0
@@ -34,6 +34,7 @@ requirements:
     - gitpython
     - pygithub <2
     - ruamel.yaml
+    - conda-forge-pinning
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Releases 3.1.2 of `conda-smithy`. Adds the `conda-forge-pinning` package as dependency (was omitted accidentally before). Other changes in the release notes.

<!--
Please add any other relevant info below:
-->
