### PR TITLE
Require Python 3.5+

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,10 +21,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.5
     - pip
   run:
-    - python
+    - python >=3.5
     - conda >=4.2
     - conda-build >=3.8.1
     - jinja2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 3745e6a6d244d0769a5520824aba08c19de494f0bbdcd4bd092955b158b1d59c
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script:
     - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"


### PR DESCRIPTION
As conda-smithy now is Python 3 only and requires at least Python 3.5, make that a minimum version for building and installing conda-smithy.

Note: We should probably pull older conda-smithy 3.2 packages that do not have this constraint so that users do not accidentally install these under Python 2 and run into problems.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
