### PR TITLE
Drop git on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,10 @@ requirements:
     - pycryptodome
     - gitpython
     - git                             # [unix]
-    - m2-git                          # [win]
+    # TODO: Both `git` & `m2-git` on Windows have problems.
+    #       For now, install neither. Hopefully we can find
+    #       a better solution in the future.
+    #- m2-git                          # [win]
     - pygithub >=2,<3
     - ruamel.yaml >=0.16
     - conda-forge-pinning

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: d6240b78efdb786212dda051d782a139911b2484b7a183378ce151822c073cb9
 
 build:
-  number: 1
+  number: 2
   noarch: python
   string: unix_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [unix]
   string: win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}   # [win]


### PR DESCRIPTION
It looks like `m2-git` is broken for users as demonstrated by the discussion at the end of PR ( https://github.com/conda-forge/conda-smithy-feedstock/pull/277 ). However `git` breaks other MSYS2 packages used in conda-forge ( https://github.com/conda-forge/git-feedstock/issues/135 ). So for now this drops git on Windows altogether ( https://github.com/conda-forge/conda-smithy-feedstock/issues/290#issuecomment-2128210093 ). Hopefully we can find a better solution for Windows users with git in the future

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
