### PR TITLE
don't require `python {{ python_min }}` in testing; breaks `downstreams:` usage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,9 +90,7 @@ test:
       --ignore tests/test_cli.py 
       --ignore tests/test_configure_feedstock.py
       -k "not test_maintainer_team_exists"
-      {% if py>=311 -%}
       -k "not test_lint_recipe_parses"
-      {%- endif %}
 
 about:
   home: https://github.com/conda-forge/conda-smithy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,7 +90,6 @@ test:
       --ignore tests/test_cli.py 
       --ignore tests/test_configure_feedstock.py
       -k "not test_maintainer_team_exists"
-      -k "not test_lint_recipe_parses"
 
 about:
   home: https://github.com/conda-forge/conda-smithy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,7 @@ source:
 build:
   number: 1
   noarch: python
-  string: unix_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [unix]
-  string: win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}   # [win]
+  string: {{ "win" if win else "unix" }}_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script:
     - {{ PYTHON }} -m pip install . --no-deps -vv
     - rm -f "${PREFIX}/bin/conda"           # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: abb1c1d9e7a38126aba41f3cd0709a764a953b9fcd6541e5cd1d666dc67771fe
 
 build:
-  number: 0
+  number: 1
   noarch: python
   string: unix_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [unix]
   string: win_pyh{{ PKG_HASH }}_{{ PKG_BUILDNUM }}   # [win]
@@ -70,9 +70,8 @@ test:
     - conda_smithy.ci_register
     - conda_smithy.configure_feedstock
   requires:
-    # no python min here due to testing requirements on linux
-    - python                    # [unix]
-    - python  {{ python_min }}  # [win]
+    # no python_min here to be able to test smithy as a downstream (e.g. conda-feedstock)
+    - python
     - mock
     - pytest
     - pytest-cov

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,8 +77,8 @@ test:
     - pytest-cov
     - pydantic >=2,<3
     - conda-forge-tick      # [unix]
-    - conda-souschef        # [unix]
-    - conda-recipe-manager  # [unix]
+    - conda-souschef
+    - conda-recipe-manager
   source_files:
     - tests/
   commands:
@@ -90,7 +90,7 @@ test:
       --ignore tests/test_cli.py 
       --ignore tests/test_configure_feedstock.py
       -k "not test_maintainer_team_exists"
-      {% if win -%}
+      {% if py>=311 -%}
       -k "not test_lint_recipe_parses"
       {%- endif %}
 


### PR DESCRIPTION
This breaks `downstreams:` testing in `conda`, see https://github.com/conda-forge/conda-feedstock/pull/243